### PR TITLE
MAINT: use inst_id

### DIFF
--- a/pysatSpaceWeather/instruments/sw_dst.py
+++ b/pysatSpaceWeather/instruments/sw_dst.py
@@ -43,7 +43,7 @@ logger = logging.getLogger(__name__)
 platform = 'sw'
 name = 'dst'
 tags = {'': ''}
-sat_ids = {'': ['']}
+inst_ids = {'': ['']}
 _test_dates = {'': {'': dt.datetime(2007, 1, 1)}}
 # Other tags assumed to be True
 _test_download_travis = {'': {'': False}}
@@ -63,7 +63,7 @@ def init(self):
     return
 
 
-def load(fnames, tag=None, sat_id=None):
+def load(fnames, tag=None, inst_id=None):
     """Load Kp index files
 
     Parameters
@@ -72,7 +72,7 @@ def load(fnames, tag=None, sat_id=None):
         Series of filenames
     tag : str or NoneType
         tag or None (default=None)
-    sat_id : str or NoneType
+    inst_id : str or NoneType
         satellite id or None (default=None)
 
     Returns
@@ -144,7 +144,7 @@ def load(fnames, tag=None, sat_id=None):
     return data, pysat.Meta()
 
 
-def list_files(tag=None, sat_id=None, data_path=None, format_str=None):
+def list_files(tag=None, inst_id=None, data_path=None, format_str=None):
     """Return a Pandas Series of every file for chosen satellite data
 
     Parameters
@@ -152,7 +152,7 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None):
     tag : string or NoneType
         Denotes type of file to load.  Accepted types are '1min' and '5min'.
         (default=None)
-    sat_id : string or NoneType
+    inst_id : string or NoneType
         Specifies the satellite ID for a constellation.  Not used.
         (default=None)
     data_path : string or NoneType
@@ -196,7 +196,7 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None):
                                   'routine for Dst')))
 
 
-def download(date_array, tag, sat_id, data_path, user=None, password=None):
+def download(date_array, tag, inst_id, data_path, user=None, password=None):
     """Routine to download Dst index data
 
     Parameters
@@ -204,7 +204,7 @@ def download(date_array, tag, sat_id, data_path, user=None, password=None):
     tag : string or NoneType
         Denotes type of file to load.
         (default=None)
-    sat_id : string or NoneType
+    inst_id : string or NoneType
         Specifies the satellite ID for a constellation.  Not used.
         (default=None)
     data_path : string or NoneType

--- a/pysatSpaceWeather/instruments/sw_f107.py
+++ b/pysatSpaceWeather/instruments/sw_f107.py
@@ -68,9 +68,9 @@ tags = {'': 'Daily LASP value of F10.7',
         'daily': 'Daily SWPC solar indices (contains last 30 days)',
         'forecast': 'SWPC Forecast F107 data next (3 days)',
         '45day': 'Air Force 45-day Forecast'}
-# dict keyed by sat_id that lists supported tags for each sat_id
-sat_ids = {'': ['', 'all', 'prelim', 'daily', 'forecast', '45day']}
-# dict keyed by sat_id that lists supported tags and a good day of test data
+# dict keyed by inst_id that lists supported tags for each inst_id
+inst_ids = {'': ['', 'all', 'prelim', 'daily', 'forecast', '45day']}
+# dict keyed by inst_id that lists supported tags and a good day of test data
 # generate todays date to support loading forecast data
 now = dt.datetime.now()
 today = dt.datetime(now.year, now.month, now.day)
@@ -100,7 +100,7 @@ def init(self):
     return
 
 
-def load(fnames, tag=None, sat_id=None):
+def load(fnames, tag=None, inst_id=None):
     """Load F10.7 index files
 
     Parameters
@@ -109,7 +109,7 @@ def load(fnames, tag=None, sat_id=None):
         Series of filenames
     tag : str or NoneType
         tag or None (default=None)
-    sat_id : str or NoneType
+    inst_id : str or NoneType
         satellite id or None (default=None)
 
     Returns
@@ -194,7 +194,7 @@ def load(fnames, tag=None, sat_id=None):
     return result, meta
 
 
-def list_files(tag=None, sat_id=None, data_path=None, format_str=None):
+def list_files(tag=None, inst_id=None, data_path=None, format_str=None):
     """Return a Pandas Series of every file for F10.7 data
 
     Parameters
@@ -202,7 +202,7 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None):
     tag : string or NoneType
         Denotes type of file to load.
         (default=None)
-    sat_id : string or NoneType
+    inst_id : string or NoneType
         Specifies the satellite ID for a constellation.  Not used.
         (default=None)
     data_path : string or NoneType
@@ -349,7 +349,7 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None):
                                    'routine for F107')))
 
 
-def download(date_array, tag, sat_id, data_path, user=None, password=None):
+def download(date_array, tag, inst_id, data_path, user=None, password=None):
     """Routine to download F107 index data
 
     Parameters
@@ -357,7 +357,7 @@ def download(date_array, tag, sat_id, data_path, user=None, password=None):
     tag : string or NoneType
         Denotes type of file to load.  Accepted types are '' and 'forecast'.
         (default=None)
-    sat_id : string or NoneType
+    inst_id : string or NoneType
         Specifies the satellite ID for a constellation.  Not used.
         (default=None)
     data_path : string or NoneType
@@ -450,7 +450,7 @@ def download(date_array, tag, sat_id, data_path, user=None, password=None):
 
         # Get the local files, to ensure that the version 1 files are
         # downloaded again if more data has been added
-        local_files = list_files(tag, sat_id, data_path)
+        local_files = list_files(tag, inst_id, data_path)
 
         # To avoid downloading multiple files, cycle dates based on file length
         date = date_array[0]

--- a/pysatSpaceWeather/instruments/sw_kp.py
+++ b/pysatSpaceWeather/instruments/sw_kp.py
@@ -79,7 +79,7 @@ name = 'kp'
 tags = {'': '',
         'forecast': 'SWPC Forecast data next (3 days)',
         'recent': 'SWPC provided Kp for past 30 days'}
-sat_ids = {'': ['', 'forecast', 'recent']}
+inst_ids = {'': ['', 'forecast', 'recent']}
 
 # generate todays date to support loading forecast data
 now = dt.datetime.now()
@@ -106,7 +106,7 @@ def init(self):
     return
 
 
-def load(fnames, tag=None, sat_id=None):
+def load(fnames, tag=None, inst_id=None):
     """Load Kp index files
 
     Parameters
@@ -115,7 +115,7 @@ def load(fnames, tag=None, sat_id=None):
         Series of filenames
     tag : str or NoneType
         tag or None (default=None)
-    sat_id : str or NoneType
+    inst_id : str or NoneType
         satellite id or None (default=None)
 
     Returns
@@ -201,7 +201,7 @@ def load(fnames, tag=None, sat_id=None):
     return result, meta
 
 
-def list_files(tag=None, sat_id=None, data_path=None, format_str=None):
+def list_files(tag=None, inst_id=None, data_path=None, format_str=None):
     """Return a Pandas Series of every file for chosen satellite data
 
     Parameters
@@ -209,7 +209,7 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None):
     tag : string or NoneType
         Denotes type of file to load.
         (default=None)
-    sat_id : string or NoneType
+    inst_id : string or NoneType
         Specifies the satellite ID for a constellation.  Not used.
         (default=None)
     data_path : string or NoneType
@@ -277,7 +277,7 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None):
                                    'routine for Kp')))
 
 
-def download(date_array, tag, sat_id, data_path, user=None, password=None):
+def download(date_array, tag, inst_id, data_path, user=None, password=None):
     """Routine to download Kp index data
 
     Parameters
@@ -285,7 +285,7 @@ def download(date_array, tag, sat_id, data_path, user=None, password=None):
     tag : string or NoneType
         Denotes type of file to load.  Accepted types are '' and 'forecast'.
         (default=None)
-    sat_id : string or NoneType
+    inst_id : string or NoneType
         Specifies the satellite ID for a constellation.  Not used.
         (default=None)
     data_path : string or NoneType


### PR DESCRIPTION
Addresses pysat/pysat#473, test with pysat/pysat#556

Updates use of `sat_id` to `inst_id`.

Passing locally with the `break/inst_id` branch of pysat.  Expected to fail on Travis until pysat/pysat#556 is merged.