### PR TITLE
BUG: pysat upstream updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,5 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.0.2] - 2020-XX-XX
+- Added real-time ACE instrument
+- Fixed bugs introduced by changes in pysat-3.0
+
+
 ## [0.0.1] - 2020-08-13
-- initial port of existing routines from pysat
+- Initial port of existing routines from pysat

--- a/pysatSpaceWeather/instruments/sw_ace.py
+++ b/pysatSpaceWeather/instruments/sw_ace.py
@@ -38,7 +38,6 @@ from pysat.Instrument objects.
 """
 
 import datetime as dt
-import logging
 import numpy as np
 import os
 import pandas as pds
@@ -48,7 +47,7 @@ import pysat
 
 from pysatSpaceWeather.instruments.methods import ace as mm_ace
 
-logger = logging.getLogger(__name__)
+logger = pysat.logger
 
 # ----------------------------------------------------------------------------
 # Instrument attributes
@@ -414,7 +413,7 @@ def download(date_array, tag, inst_id, data_path):
 
         if(len(date_array) > 1 or date_array[0].year != now.year
            or date_array[0].month != now.month or date_array[0] != now.day):
-            logging.warning('real-time data only available for current day')
+            logger.warning('real-time data only available for current day')
     else:
         data_rate = 1 if inst_id in ['mag', 'swepam'] else 5
         file_fmt = '_'.join(["%Y%m%d", "ace", inst_id,

--- a/pysatSpaceWeather/instruments/sw_dst.py
+++ b/pysatSpaceWeather/instruments/sw_dst.py
@@ -27,7 +27,6 @@ of the National Science Foundation.
 """
 
 import datetime as dt
-import logging
 import ftplib
 import os
 import numpy as np
@@ -37,7 +36,7 @@ import pandas as pds
 import pysat
 from pysatSpaceWeather.instruments.methods import sw as mm_sw
 
-logger = logging.getLogger(__name__)
+logger = pysat.logger
 
 # ----------------------------------------------------------------------------
 # Instrument attributes

--- a/pysatSpaceWeather/instruments/sw_f107.py
+++ b/pysatSpaceWeather/instruments/sw_f107.py
@@ -46,7 +46,6 @@ is not appropriate for 'forecast' data.
 import datetime as dt
 import ftplib
 import json
-import logging
 import numpy as np
 import os
 import requests
@@ -58,7 +57,7 @@ import pandas as pds
 import pysat
 from pysatSpaceWeather.instruments.methods import sw as mm_sw
 
-logger = logging.getLogger(__name__)
+logger = pysat.logger
 
 # ----------------------------------------------------------------------------
 # Instrument attributes

--- a/pysatSpaceWeather/instruments/sw_kp.py
+++ b/pysatSpaceWeather/instruments/sw_kp.py
@@ -60,7 +60,6 @@ filter_geoquiet
 
 import datetime as dt
 import ftplib
-import logging
 import numpy as np
 import os
 import pandas as pds
@@ -72,7 +71,7 @@ from pysat.utils.time import parse_date
 
 from pysatSpaceWeather.instruments.methods import sw as mm_sw
 
-logger = logging.getLogger(__name__)
+logger = pysat.logger
 
 # ----------------------------------------------------------------------------
 # Instrument attributes
@@ -274,7 +273,7 @@ def list_files(tag=None, inst_id=None, data_path=None, format_str=None):
                 format_str = 'kp{year:2d}{month:02d}.tab'
             out = pysat.Files.from_os(data_path=data_path,
                                       format_str=format_str,
-                                      two_digit_year_break=94)
+                                      two_digit_year_break=99)
             if not out.empty:
                 out.loc[out.index[-1] + pds.DateOffset(months=1)
                         - pds.DateOffset(days=1)] = out.iloc[-1]

--- a/pysatSpaceWeather/tests/test_sw.py
+++ b/pysatSpaceWeather/tests/test_sw.py
@@ -221,12 +221,14 @@ class TestSwKpCombine():
         # Set combination testing input
         self.test_day = dt.datetime(2019, 3, 18)
         self.combine = {"standard_inst": pysat.Instrument(inst_module=sw_kp,
-                                                          tag=""),
+                                                          tag="",
+                                                          update_files=True),
                         "recent_inst": pysat.Instrument(inst_module=sw_kp,
-                                                        tag="recent"),
+                                                        tag="recent",
+                                                        update_files=True),
                         "forecast_inst":
                         pysat.Instrument(inst_module=sw_kp,
-                                         tag="forecast"),
+                                         tag="forecast", update_files=True),
                         "start": self.test_day - dt.timedelta(days=30),
                         "stop": self.test_day + dt.timedelta(days=3),
                         "fill_val": -1}
@@ -473,7 +475,8 @@ class TestSWF107Combine():
 
         # Set combination testing input
         self.test_day = dt.datetime(2019, 3, 16)
-        self.combineInst = {tag: pysat.Instrument(inst_module=sw_f107, tag=tag)
+        self.combineInst = {tag: pysat.Instrument(inst_module=sw_f107, tag=tag,
+                                                  update_files=True)
                             for tag in sw_f107.tags.keys()}
         self.combineTimes = {"start": self.test_day - dt.timedelta(days=30),
                              "stop": self.test_day + dt.timedelta(days=3)}


### PR DESCRIPTION
Fixed the issues introduced by upstream changes.  Addresses issues #9, #10, and #11 

To test, run unit tests.

```
=============================== warnings summary ===============================
pysatSpaceWeather/tests/test_sw.py::TestSWKp::test_convert_ap_to_kp_middle
  /Users/aburrell/Programs/Git/pysatSpaceWeather/pysatSpaceWeather/tests/test_sw.py:152: SettingWithCopyWarning: 
  A value is trying to be set on a copy of a slice from a DataFrame
  
  See the caveats in the documentation: http://pandas.pydata.org/pandas-docs/stable/indexing.html#indexing-view-versus-copy
    self.testInst['3hr_ap'][8] += 1

-- Docs: https://docs.pytest.org/en/stable/warnings.html
================= 136 passed, 19 skipped, 1 warning in 25.10s ==================
```

Ran on OSX Mojave, python 3.7.