### PR TITLE
F107 prelim update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 * Added PyPi links to README and documentation
 * Deprecated F10.7 instrument tag 'all' and '', replacing them with 'historic'
 * Improved F10.7 instrument routines by combining similar code blocks
+* Fixed F10.7 load/list bugs that lead to duplicate data entries
 
 [0.0.3] - 2021-01-15
 --------------------

--- a/pysatSpaceWeather/instruments/sw_f107.py
+++ b/pysatSpaceWeather/instruments/sw_f107.py
@@ -167,7 +167,7 @@ def load(fnames, tag=None, inst_id=None):
     """
     # Get the desired file dates and file names from the daily indexed list
     file_dates = list()
-    if tag == 'historic':
+    if tag in ['historic', 'prelim']:
         unique_files = list()
         for fname in fnames:
             file_dates.append(dt.datetime.strptime(fname[-10:], '%Y-%m-%d'))
@@ -335,11 +335,10 @@ def list_files(tag=None, inst_id=None, data_path=None, format_str=None):
                     '%Y-%m-%d')
 
         elif tag == 'prelim':
-            # Files are by year (and quarter). The load routine will load a
-            # year of data
+            # Files are by year (and quarter)
             if format_str is None:
-                format_str = \
-                    'f107_prelim_{year:04d}_{month:02d}_v{version:01d}.txt'
+                format_str = ''.join(['f107_prelim_{year:04d}_{month:02d}',
+                                      '_v{version:01d}.txt'])
             out_files = pysat.Files.from_os(data_path=data_path,
                                             format_str=format_str)
 
@@ -375,6 +374,8 @@ def list_files(tag=None, inst_id=None, data_path=None, format_str=None):
                 out_files = pds.concat(new_files, sort=True)
                 out_files = out_files.dropna()
                 out_files = out_files.sort_index()
+                out_files = out_files + '_' + out_files.index.strftime(
+                    '%Y-%m-%d')
 
         elif tag in ['daily', 'forecast', '45day']:
             format_str = ''.join(['f107_', tag,


### PR DESCRIPTION
# Description

Addresses #52 by fixing the forced year-long loading of preliminary F10.7 data.

# Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

```
import datetime as dt
import pysatSpaceWeather
import pysat

f107_prelim = pysat.Instrument(inst_module=pysatSpaceWeather.instruments.sw_f107, tag='prelim', update_files=True)
f107_prelim.download(start=dt.datetime(2020, 1, 1), stop=dt.datetime(2020, 2, 1))
f107_prelim.load(2020, 1)
print(f107_prelim.data)

            f107  ssn  ss_area  new_reg  ...  x_flare o1_flare  o2_flare  o3_flare
2020-01-01    72    0        0        0  ...        0        0         0         0

[1 rows x 12 columns]
```

## Test Configuration
* Operating system: OSX Mojave
* Version number: Python 3.7
* Any details about your local setup that are relevant: pysat develop branch

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the
release checklist on the pysat wiki:
https://github.com/pysat/pysat/wiki/Checklist-for-Release
