### PR TITLE
Deprecation update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,16 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 --------------------
 * Updated the docstrings to conform to pysat standards
 * Added docstring tests to Flake8 portion of CI testing
-* Fixed bug in combine_kp that occurs if no times are provided
+* Fixed bug in `combine_kp` that occurs if no times are provided
 * Improved unit test style and expanded unit test coverage
 * Updated package organization documentation
 * Added a function to normalize ACE SWEPAM variables as described in the OMNI
   processing guide
 * Deprecated `load_csv_data` method, which was moved to pysat
 * Added the LASP predicted Dst to the Dst Instrument
+* Updated pandas usage to remove existing deprecation warnings
+* Updated `pysat.Instrument.load` calls to remove `use_header` deprecation
+  warning
 
 [0.0.4] - 2021-05-19
 --------------------

--- a/pysatSpaceWeather/instruments/methods/kp_ap.py
+++ b/pysatSpaceWeather/instruments/methods/kp_ap.py
@@ -525,7 +525,7 @@ def combine_kp(standard_inst=None, recent_inst=None, forecast_inst=None,
             load_kwargs = {'date': itime}
             if Version(pysat.__version__) > Version('3.0.1'):
                 load_kwargs['use_header'] = True
-            
+
             standard_inst.load(**load_kwargs)
 
             if notes.find("standard") < 0:

--- a/pysatSpaceWeather/instruments/sw_kp.py
+++ b/pysatSpaceWeather/instruments/sw_kp.py
@@ -221,7 +221,7 @@ def load(fnames, tag, inst_id):
             for i in np.arange(8):
                 tind = data.index + pds.DateOffset(hours=int(3 * i))
                 temp = pds.Series(data.iloc[:, i].values, index=tind)
-                data_series = data_series.append(temp)
+                data_series = pds.concat([data_series, temp])
 
             data_series = data_series.sort_index()
             data_series.index.name = 'time'

--- a/pysatSpaceWeather/tests/test_methods_f107.py
+++ b/pysatSpaceWeather/tests/test_methods_f107.py
@@ -7,6 +7,7 @@
 
 import datetime as dt
 import numpy as np
+from packaging.version import Version
 
 import pandas as pds
 import pysat
@@ -135,12 +136,17 @@ class TestSWF107Combine(object):
                              for tag in sw_f107.tags.keys()}
         self.combine_times = {"start": self.test_day - dt.timedelta(days=30),
                               "stop": self.test_day + dt.timedelta(days=3)}
+        self.load_kwargs = {}
+        if Version(pysat.__version__) > Version('3.0.1'):
+            self.load_kwargs['use_header'] = True
+
         return
 
     def teardown(self):
         """Clean up previous testing setup."""
         pysat.params.data['data_dirs'] = self.saved_path
         del self.combine_inst, self.test_day, self.combine_times
+        del self.load_kwargs
         return
 
     def test_combine_f107_none(self):
@@ -193,8 +199,9 @@ class TestSWF107Combine(object):
 
         self.combine_inst['historic'].load(
             date=self.combine_inst['historic'].lasp_stime,
-            end_date=self.combine_times['start'])
-        self.combine_inst['forecast'].load(date=self.test_day)
+            end_date=self.combine_times['start'], **self.load_kwargs)
+        self.combine_inst['forecast'].load(date=self.test_day,
+                                           **self.load_kwargs)
 
         f107_inst = mm_f107.combine_f107(self.combine_inst['historic'],
                                          self.combine_inst['forecast'])

--- a/pysatSpaceWeather/tests/test_methods_kp.py
+++ b/pysatSpaceWeather/tests/test_methods_kp.py
@@ -373,7 +373,7 @@ class TestSwKpCombine(object):
         combo_in['standard_inst'].load(date=self.combine['start'],
                                        **self.load_kwargs)
         combo_in['recent_inst'].load(date=self.test_day,
-                                       **self.load_kwargs)
+                                     **self.load_kwargs)
         combo_in['forecast_inst'].load(date=self.test_day,
                                        **self.load_kwargs)
         combo_in['stop'] = combo_in['forecast_inst'].index[-1]

--- a/pysatSpaceWeather/tests/test_methods_kp.py
+++ b/pysatSpaceWeather/tests/test_methods_kp.py
@@ -7,6 +7,7 @@
 
 import datetime as dt
 import numpy as np
+from packaging.version import Version
 
 import pandas as pds
 import pysat
@@ -25,7 +26,12 @@ class TestSWKp(object):
         # Load a test instrument
         self.testInst = pysat.Instrument('pysat', 'testing', num_samples=12)
         self.test_time = pysat.instruments.pysat_testing._test_dates['']['']
-        self.testInst.load(date=self.test_time)
+
+        load_kwargs = {'date': self.test_time}
+        if Version(pysat.__version__) > Version('3.0.1'):
+            load_kwargs['use_header'] = True
+
+        self.testInst.load(**load_kwargs)
 
         # Create Kp data
         self.testInst.data.index = pds.DatetimeIndex(data=[
@@ -65,8 +71,9 @@ class TestSWKp(object):
         """Test conversion of Kp to ap with fill values."""
 
         # Set the first value to a fill value, then calculate ap
-        fill_val = self.testInst.meta.labels.fill_val
-        self.testInst['Kp'][0] = self.testInst.meta['Kp'][fill_val]
+        fill_label = self.testInst.meta.labels.fill_val
+        fill_value = self.testInst.meta['Kp', fill_label]
+        self.testInst.data.at[self.testInst.index[0], 'Kp'] = fill_value
         kp_ap.convert_3hr_kp_to_ap(self.testInst)
 
         # Test non-fill ap values
@@ -79,9 +86,8 @@ class TestSWKp(object):
 
         # Test the fill value in the data and metadata
         assert np.isnan(self.testInst['3hr_ap'][0])
-        assert np.isnan(self.testInst.meta['3hr_ap'][fill_val])
+        assert np.isnan(self.testInst.meta['3hr_ap'][fill_label])
 
-        del fill_val
         return
 
     def test_convert_kp_to_ap_bad_input(self):
@@ -162,7 +168,8 @@ class TestSWKp(object):
         """Test conversion of ap to Kp where ap is not an exact Kp value."""
 
         kp_ap.convert_3hr_kp_to_ap(self.testInst)
-        self.testInst['3hr_ap'][8] += 1
+        new_val = self.testInst['3hr_ap'][8] + 1
+        self.testInst.data.at[self.testInst.index[8], '3hr_ap'] = new_val
         kp_out, kp_meta = kp_ap.convert_ap_to_kp(self.testInst['3hr_ap'])
 
         # Assert original and coverted there and back Kp are equal
@@ -172,7 +179,6 @@ class TestSWKp(object):
         assert 'Kp' in kp_meta.keys()
         assert(kp_meta['Kp'][kp_meta.labels.fill_val] == -1)
 
-        del kp_out, kp_meta
         return
 
     def test_convert_ap_to_kp_nan_input(self):
@@ -209,25 +215,24 @@ class TestSWKp(object):
         """Test conversion of ap to Kp with fill values."""
 
         # Set the first Kp value to a fill value
-        fill_val = self.testInst.meta.labels.fill_val
-        self.testInst['Kp'][0] = self.testInst.meta['Kp', fill_val]
+        fill_label = self.testInst.meta.labels.fill_val
+        fill_value = self.testInst.meta['Kp', fill_label]
+        self.testInst.data.at[self.testInst.index[0], 'Kp'] = fill_value
 
         # Calculate ap
         kp_ap.convert_3hr_kp_to_ap(self.testInst)
 
         # Recalculate Kp from ap
-        kp_out, kp_meta = kp_ap.convert_ap_to_kp(
-            self.testInst['3hr_ap'],
-            fill_val=self.testInst.meta['Kp', fill_val])
+        kp_out, kp_meta = kp_ap.convert_ap_to_kp(self.testInst['3hr_ap'],
+                                                 fill_val=fill_value)
 
         # Test non-fill ap values
         assert all(abs(kp_out[1:] - self.testInst.data['Kp'][1:]) < 1.0e-4)
 
         # Test the fill value in the data and metadata
         assert np.isnan(kp_out[0])
-        assert np.isnan(kp_meta['Kp'][fill_val])
+        assert np.isnan(kp_meta['Kp'][fill_label])
 
-        del fill_val, kp_out, kp_meta
         return
 
     @pytest.mark.parametrize("filter_kwargs,ngood", [
@@ -288,12 +293,16 @@ class TestSwKpCombine(object):
                         "start": self.test_day - dt.timedelta(days=30),
                         "stop": self.test_day + dt.timedelta(days=3),
                         "fill_val": -1}
+        self.load_kwargs = {}
+        if Version(pysat.__version__) > Version('3.0.1'):
+            self.load_kwargs['use_header'] = True
+
         return
 
     def teardown(self):
         """Clean up previous testing."""
         pysat.params.data['data_dirs'] = self.saved_path
-        del self.combine, self.test_day, self.saved_path
+        del self.combine, self.test_day, self.saved_path, self.load_kwargs
         return
 
     def test_combine_kp_none(self):
@@ -361,9 +370,12 @@ class TestSwKpCombine(object):
         combo_in = {kk: self.combine[kk] for kk in
                     ['standard_inst', 'recent_inst', 'forecast_inst']}
 
-        combo_in['standard_inst'].load(date=self.combine['start'])
-        combo_in['recent_inst'].load(date=self.test_day)
-        combo_in['forecast_inst'].load(date=self.test_day)
+        combo_in['standard_inst'].load(date=self.combine['start'],
+                                       **self.load_kwargs)
+        combo_in['recent_inst'].load(date=self.test_day,
+                                       **self.load_kwargs)
+        combo_in['forecast_inst'].load(date=self.test_day,
+                                       **self.load_kwargs)
         combo_in['stop'] = combo_in['forecast_inst'].index[-1]
 
         kp_inst = kp_ap.combine_kp(**combo_in)
@@ -461,7 +473,12 @@ class TestSWAp(object):
         """Create a clean testing setup."""
         self.testInst = pysat.Instrument('pysat', 'testing', num_samples=10)
         self.test_time = pysat.instruments.pysat_testing._test_dates['']['']
-        self.testInst.load(date=self.test_time)
+
+        load_kwargs = {'date': self.test_time}
+        if Version(pysat.__version__) > Version('3.0.1'):
+            load_kwargs['use_header'] = True
+
+        self.testInst.load(**load_kwargs)
 
         # Create 3 hr Ap data
         self.testInst.data.index = pds.DatetimeIndex(data=[

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 netCDF4
 numpy
+packaging
 pandas
 pysat >= 3.0.1
 requests

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,7 @@ zip_safe = False
 packages = find:
 install_requires = netCDF4
 		   numpy
+		   packaging
 		   pandas
 		   pysat
 		   requests


### PR DESCRIPTION
# Description

Addresses #74, #75, and #76.  Also removes the future 'use_header' deprecation warning and the pandas "set value with copy" warning.

# Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Ran unit tests locally with main and develop branches of pysat.

## Test Configuration
* Operating system: OS X Big Sur
* Version number: Python 3.9
* Any details about your local setup that are relevant

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the
release checklist on the pysat wiki:
https://github.com/pysat/pysat/wiki/Checklist-for-Release
