### PR TITLE
BUG: Generalize f107 historic data check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Change Log
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
+[0.0.6] - 2022-0X-XX
+--------------------
+* Updated `sw_f107` to reflect changes in the `historic` data file format
+
 [0.0.5] - 2022-06-10
 --------------------
 * Updated the docstrings to conform to pysat standards

--- a/pysatSpaceWeather/instruments/sw_f107.py
+++ b/pysatSpaceWeather/instruments/sw_f107.py
@@ -205,6 +205,18 @@ def load(fnames, tag='', inst_id=''):
                       meta.labels.fill_val: np.nan,
                       meta.labels.min_val: 0,
                       meta.labels.max_val: 400}
+    elif tag == 'historic':
+        meta['f107_observed'] = meta['f107']
+        meta['f107_observed'] = {
+            meta.labels.desc:
+                'Raw F10.7 cm radio flux in Solar Flux Units (SFU)'}
+        meta['f107_adjusted'] = meta['f107_observed']
+        meta['f107_adjusted'] = {
+            meta.labels.desc:
+            'F10.7 cm radio flux in Solar Flux Units (SFU) normalized to 1-AU'}
+        meta['f107'] = {
+            meta.labels.desc: meta['f107_adjusted', meta.labels.desc]}
+
     elif tag == 'daily' or tag == 'prelim':
         meta['ssn'] = {meta.labels.units: '',
                        meta.labels.name: 'Sunspot Number',
@@ -477,6 +489,10 @@ def download(date_array, tag, inst_id, data_path, update_files=False):
                         idx, = np.where(data[var] == -99999.0)
                         data.iloc[idx, :] = np.nan
 
+                    # Copy 'f107_adjusted` data to minimize disruption caused
+                    # by file format change, late June 2022
+                    data['f107'] = data['f107_adjusted']
+
                     # Create a local CSV file
                     data.to_csv(data_file, header=True)
     elif tag == 'prelim':
@@ -604,7 +620,7 @@ def download(date_array, tag, inst_id, data_path, update_files=False):
                               'forecast, not archived forecasts')))
         # Set the download webpage
         furl = ''.join(('https://services.swpc.noaa.gov/text/',
-                        '3-day-solar-geomag-predictions.txt'))
+                                '3-day-solar-geomag-predictions.txt'))
         req = requests.get(furl)
 
         # Parse text to get the date the prediction was generated

--- a/pysatSpaceWeather/instruments/sw_f107.py
+++ b/pysatSpaceWeather/instruments/sw_f107.py
@@ -473,8 +473,9 @@ def download(date_array, tag, inst_id, data_path, update_files=False):
                     data.index = times
 
                     # Replace fill value with NaNs
-                    idx, = np.where(data['f107'] == -99999.0)
-                    data.iloc[idx, :] = np.nan
+                    for var in data.columns:
+                        idx, = np.where(data[var] == -99999.0)
+                        data.iloc[idx, :] = np.nan
 
                     # Create a local CSV file
                     data.to_csv(data_file, header=True)

--- a/pysatSpaceWeather/instruments/sw_f107.py
+++ b/pysatSpaceWeather/instruments/sw_f107.py
@@ -624,7 +624,7 @@ def download(date_array, tag, inst_id, data_path, update_files=False):
                               'forecast, not archived forecasts')))
         # Set the download webpage
         furl = ''.join(('https://services.swpc.noaa.gov/text/',
-                                '3-day-solar-geomag-predictions.txt'))
+                        '3-day-solar-geomag-predictions.txt'))
         req = requests.get(furl)
 
         # Parse text to get the date the prediction was generated


### PR DESCRIPTION
# Description

Addresses # (issue)

LASP updated their F10.7 data format which broke current code. This is a minimal bug fix.

# Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce the problem and the solution. Including images
or test files is frequently very useful.  Please also list any relevant details
for your test configuration.

- Tested locally by downloading and loading 'historic' data from `sw_f107`

## Test Configuration
* Operating system: MacOS
* Version number: Python 3.9
* Any details about your local setup that are relevant

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the
release checklist on the pysat wiki:
https://github.com/pysat/pysat/wiki/Checklist-for-Release
