### PR TITLE
Deprecation update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 --------------------
 * Updated `sw_f107` to allow reading old and new `historic` data file format
 * Added exampled to the documentation for F10.7 and Kp methods
+* Removed warning for not using the deprecated `freq` kwarg
+* Removed deprecated function `load_csv_data`
 
 [0.0.6] - 2022-07-08
 --------------------

--- a/docs/examples/ex_f107.rst
+++ b/docs/examples/ex_f107.rst
@@ -27,8 +27,7 @@ This may be done using the
                                 tag='45day', update_files=True)
 
    # If needed, download the data
-   f107_hist.download(start=f107_hist.lasp_stime, stop=dt.datetime(2018, 4, 1),
-                      freq='MS')
+   f107_hist.download(start=f107_hist.lasp_stime, stop=dt.datetime(2018, 4, 1))
    f107_prel.download(start=f107_hist.files.files.index[-1],
                       stop=f107_prel.today())
    f107_fore.download(start=f107_fore.today())

--- a/docs/examples/ex_init.rst
+++ b/docs/examples/ex_init.rst
@@ -18,7 +18,7 @@ used as an example.
 
    f107 = pysat.Instrument(inst_module=py_sw.instruments.sw_f107,
                            tag='historic', update_files=True)
-   f107.download(start=f107.lasp_stime, stop=f107.today(), freq='MS')
+   f107.download(start=f107.lasp_stime, stop=f107.today())
    f107.load()
    print(f107)
 

--- a/pysatSpaceWeather/instruments/methods/ace.py
+++ b/pysatSpaceWeather/instruments/methods/ace.py
@@ -11,7 +11,6 @@ import numpy as np
 import os
 import pandas as pds
 import requests
-import warnings
 
 import pysat
 

--- a/pysatSpaceWeather/instruments/methods/ace.py
+++ b/pysatSpaceWeather/instruments/methods/ace.py
@@ -300,54 +300,6 @@ def common_metadata():
     return meta, status_desc
 
 
-def load_csv_data(fnames, read_csv_kwargs=None):
-    """Load CSV data from a list of files into a single DataFrame.
-
-    .. deprecated:: 0.0.5
-        `load_csv_data` will be removed in pysatSpaceWeather 0.0.6+, as it has
-        been moved to `pysat.instruments.methods.general` as of pysat 3.0.1.
-
-    Parameters
-    ----------
-    fnames : array-like
-        Series, list, or array of filenames
-    read_csv_kwargs : dict or NoneType
-        Dict of kwargs to apply to `pds.read_csv`. (default=None)
-
-    Returns
-    -------
-    data : pds.DataFrame
-        Data frame with data from all files in the fnames list
-
-    See Also
-    --------
-    pds.read_csv, pysat.instruments.methods.general.load_csv_data
-
-    """
-
-    warnings.warn("".join(["Moved to pysat.instruments.methods.general.",
-                           "load_csv_data in pysat version 3.0.1. This method ",
-                           "will be removed at the 0.0.6+ release."]),
-                  DeprecationWarning)
-
-    # Ensure the filename input is array-like
-    fnames = np.asarray(fnames)
-    if fnames.shape == ():
-        fnames = np.asarray([fnames])
-
-    # Initialize the optional kwargs
-    if read_csv_kwargs is None:
-        read_csv_kwargs = {}
-
-    # Create a list of data frames from each file
-    fdata = []
-    for fname in fnames:
-        fdata.append(pds.read_csv(fname, **read_csv_kwargs))
-
-    data = pds.DataFrame() if len(fdata) == 0 else pds.concat(fdata, axis=0)
-    return data
-
-
 def ace_swepam_hourly_omni_norm(as_inst, speed_key='sw_bulk_speed',
                                 dens_key='sw_proton_dens',
                                 temp_key='sw_ion_temp'):

--- a/pysatSpaceWeather/instruments/sw_f107.py
+++ b/pysatSpaceWeather/instruments/sw_f107.py
@@ -22,7 +22,7 @@ been successfully completed.
 ::
 
     f107 = pysat.Instrument('sw', 'f107', tag='historic')
-    f107.download(start=f107.lasp_stime, stop=f107.today(), freq='MS')
+    f107.download(start=f107.lasp_stime, stop=f107.today())
     f107.load(date=f107.lasp_stime, end_date=f107.today())
 
 
@@ -455,8 +455,6 @@ def download(date_array, tag, inst_id, data_path, update_files=False):
     if tag == 'historic':
         # Test the date array, updating it if necessary
         if date_array.freq != 'MS':
-            warnings.warn(''.join(['Historic F10.7 downloads should be invoked',
-                                   " with the `freq='MS'` option."]))
             date_array = pysat.utils.time.create_date_range(
                 dt.datetime(date_array[0].year, date_array[0].month, 1),
                 date_array[-1], freq='MS')

--- a/pysatSpaceWeather/tests/test_methods_ace.py
+++ b/pysatSpaceWeather/tests/test_methods_ace.py
@@ -7,7 +7,6 @@
 
 from packaging.version import Version
 import pytest
-import warnings
 
 import pysat
 

--- a/pysatSpaceWeather/tests/test_methods_ace.py
+++ b/pysatSpaceWeather/tests/test_methods_ace.py
@@ -48,18 +48,6 @@ class TestACEMethods(object):
         assert str(kerr.value).find('unknown ACE instrument') >= 0
         return
 
-    def test_load_csv_data_dep_warning(self):
-        """Test `load_csv_data` raises a DeprecationWarning."""
-
-        with warnings.catch_warnings(record=True) as war:
-            mm_ace.load_csv_data([])
-
-        assert len(war) == 1
-        assert war[0].category == DeprecationWarning
-        assert str(war[0].message).find(
-            "Moved to pysat.instruments.methods.general.load_csv_data") >= 0
-        return
-
 
 @pytest.mark.skipif(Version(pysat.__version__) < Version('3.0.2'),
                     reason="Requires time routine available in pysat 3.0.2+")


### PR DESCRIPTION
# Description

Addresses #86 and #50 by removing an unnecessary warning in the F10.7 historic downloads, and removed the deprecated ACE method `load_csv_data` that was moved to `pysat`.

# Type of change

Please delete options that are not relevant.

- Maintenance

# How Has This Been Tested?

```
import pysat
from pysatSpaceWeather.instruments import sw_f107

f107 = pysat.Instrument(inst_module=sw_f107, tag='historic')
f107.download(start=f107.lasp_stime)
```

There should not be any warning.

## Test Configuration
* Operating system: OS X Big Sur
* Version number: Python 3.9
* Any details about your local setup that are relevant

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the
release checklist on the pysat wiki:
https://github.com/pysat/pysat/wiki/Checklist-for-Release
