### PR TITLE
MAINT: pysat test suite and deprecations (pytest, pandas)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 [0.1.0] - 2022-XX-XX
 --------------------
 * Updated the GitHub action version numbers
+* Maintenance
+  * Updated syntax for pysat instrument testing suite
+  * Remove deprecated pytest syntax (backwards support for nose)
+  * Removed deprecated pandas syntax (iteritems)
 
 [0.0.7] - 2022-09-15
 --------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 [0.1.0] - 2022-XX-XX
 --------------------
-* Updated the GitHub action version numbers
 * Maintenance
+  * Updated the GitHub action version numbers
   * Updated syntax for pysat instrument testing suite
   * Remove deprecated pytest syntax (backwards support for nose)
   * Removed deprecated pandas syntax (iteritems)

--- a/pysatSpaceWeather/instruments/sw_dst.py
+++ b/pysatSpaceWeather/instruments/sw_dst.py
@@ -56,7 +56,7 @@ tomorrow = today + dt.timedelta(days=1)
 _test_dates = {'': {'noaa': dt.datetime(2007, 1, 1), 'lasp': today}}
 
 # Other tags assumed to be True
-_test_download_travis = {'': {'noaa': False}}
+_test_download_ci = {'': {'noaa': False}}
 
 # ----------------------------------------------------------------------------
 # Instrument methods

--- a/pysatSpaceWeather/instruments/sw_f107.py
+++ b/pysatSpaceWeather/instruments/sw_f107.py
@@ -375,7 +375,7 @@ def list_files(tag='', inst_id='', data_path='', format_str=None):
             orig_files = out_files.sort_index().copy()
             new_files = list()
 
-            for orig in orig_files.iteritems():
+            for orig in orig_files.items():
                 # Version determines each file's valid length
                 version = int(orig[1].split("_v")[1][0])
                 doff = pds.DateOffset(years=1) if version == 2 \

--- a/pysatSpaceWeather/instruments/sw_f107.py
+++ b/pysatSpaceWeather/instruments/sw_f107.py
@@ -104,7 +104,7 @@ _test_dates = {'': {'historic': dt.datetime(2009, 1, 1),
                     '45day': tomorrow}}
 
 # Other tags assumed to be True
-_test_download_travis = {'': {'prelim': False}}
+_test_download_ci = {'': {'prelim': False}}
 
 # ----------------------------------------------------------------------------
 # Instrument methods

--- a/pysatSpaceWeather/instruments/sw_kp.py
+++ b/pysatSpaceWeather/instruments/sw_kp.py
@@ -96,7 +96,7 @@ _test_dates = {'': {'': dt.datetime(2009, 1, 1),
                     'recent': today}}
 
 # Other tags assumed to be True
-_test_download_travis = {'': {'': False}}
+_test_download_ci = {'': {'': False}}
 
 # ----------------------------------------------------------------------------
 # Instrument methods

--- a/pysatSpaceWeather/tests/test_instruments.py
+++ b/pysatSpaceWeather/tests/test_instruments.py
@@ -1,79 +1,30 @@
-#!/usr/bin/env python
-# Full license can be found in License.md
-# Full author list can be found in .zenodo.json file
-# DOI:10.5281/zenodo.3986138
-# ----------------------------------------------------------------------------
-"""Standard pysat tests for pysatSpaceWeather Instruments."""
+"""Unit and Integration Tests for each instrument module.
 
-import tempfile
+Note
+----
+Imports test methods from pysat.tests.instrument_test_class
 
-import pytest
-
-# Import the test classes from pysat
-import pysat
-from pysat.tests.instrument_test_class import InstTestClass
-from pysat.utils import generate_instrument_list
+"""
 
 # Make sure to import your instrument library here
 import pysatSpaceWeather
 
-# Developers for instrument libraries should update the following line to
-# point to their own library package
-# e.g., instruments = generate_instrument_list(inst_loc=mypackage.instruments)
-instruments = generate_instrument_list(inst_loc=pysatSpaceWeather.instruments)
-
-# The following lines apply the custom instrument lists to each type of test
-method_list = [func for func in dir(InstTestClass)
-               if callable(getattr(InstTestClass, func))]
-
-# Search tests for iteration via pytestmark, update instrument list
-for method in method_list:
-    if hasattr(getattr(InstTestClass, method), 'pytestmark'):
-        # Get list of names of pytestmarks
-        Nargs = len(getattr(InstTestClass, method).pytestmark)
-        names = [getattr(InstTestClass, method).pytestmark[j].name
-                 for j in range(0, Nargs)]
-        # Add instruments from your library
-        if 'all_inst' in names:
-            mark = pytest.mark.parametrize("inst_name", instruments['names'])
-            getattr(InstTestClass, method).pytestmark.append(mark)
-        elif 'download' in names:
-            mark = pytest.mark.parametrize("inst_dict", instruments['download'])
-            getattr(InstTestClass, method).pytestmark.append(mark)
-        elif 'no_download' in names:
-            mark = pytest.mark.parametrize("inst_dict",
-                                           instruments['no_download'])
-            getattr(InstTestClass, method).pytestmark.append(mark)
+# Import the test classes from pysat
+from pysat.tests.classes import cls_instrument_library as clslib
 
 
-class TestInstruments(InstTestClass):
-    """Test class for pysatSpaceWeather Instruments."""
+# Tell the standard tests which instruments to run each test on.
+# Need to return instrument list for custom tests.
+instruments = clslib.InstLibTests.initialize_test_package(
+    clslib.InstLibTests, inst_loc=pysatSpaceWeather.instruments)
 
-    def setup_class(self):
-        """Create a clean the testing setup."""
-        # Make sure to use a temporary directory so that the user's setup is
-        # not altered
-        self.tempdir = tempfile.TemporaryDirectory()
-        self.saved_path = pysat.params['data_dirs']
-        pysat.params.data['data_dirs'] = [self.tempdir.name]
 
-        # Developers for instrument libraries should update the following line
-        # to point to their own subpackage location, e.g.,
-        # self.inst_loc = mypackage.instruments
-        self.inst_loc = pysatSpaceWeather.instruments
-        return
+class TestInstruments(clslib.InstLibTests):
+    """Main class for instrument tests.
 
-    def teardown_class(self):
-        """Clean up previous testing setup."""
-        pysat.params.data['data_dirs'] = self.saved_path
-        self.tempdir.cleanup()
-        del self.inst_loc, self.saved_path, self.tempdir
-        return
+    Note
+    ----
+    All standard tests, setup, and teardown inherited from the core pysat
+    instrument test class.
 
-    def setup_method(self):
-        """Create a clean testing setup."""
-        return
-
-    def teardown_method(self):
-        """Clean up previous testing setup."""
-        return
+    """

--- a/pysatSpaceWeather/tests/test_methods_ace.py
+++ b/pysatSpaceWeather/tests/test_methods_ace.py
@@ -16,12 +16,12 @@ from pysatSpaceWeather.instruments.methods import ace as mm_ace
 class TestACEMethods(object):
     """Test class for ACE methods."""
 
-    def setup(self):
+    def setup_method(self):
         """Create a clean testing setup."""
         self.out = None
         return
 
-    def teardown(self):
+    def setup_teardown(self):
         """Clean up previous testing setup."""
         del self.out
         return
@@ -53,7 +53,7 @@ class TestACEMethods(object):
 class TestACESWEPAMMethods(object):
     """Test class for ACE SWEPAM methods."""
 
-    def setup(self):
+    def setup_method(self):
         """Create a clean testing setup."""
         self.testInst = pysat.Instrument('pysat', 'testing', use_header=True)
         self.testInst.load(date=self.testInst.inst_module._test_dates[''][''])
@@ -61,7 +61,7 @@ class TestACESWEPAMMethods(object):
         self.omni_keys = ['sw_proton_dens_norm', 'sw_ion_temp_norm']
         return
 
-    def teardown(self):
+    def setup_teardown(self):
         """Clean up previous testing setup."""
         del self.testInst
         return

--- a/pysatSpaceWeather/tests/test_methods_ace.py
+++ b/pysatSpaceWeather/tests/test_methods_ace.py
@@ -55,7 +55,7 @@ class TestACESWEPAMMethods(object):
 
     def setup(self):
         """Create a clean testing setup."""
-        self.testInst = pysat.Instrument('pysat', 'testing')
+        self.testInst = pysat.Instrument('pysat', 'testing', use_header=True)
         self.testInst.load(date=self.testInst.inst_module._test_dates[''][''])
 
         self.omni_keys = ['sw_proton_dens_norm', 'sw_ion_temp_norm']

--- a/pysatSpaceWeather/tests/test_methods_ace.py
+++ b/pysatSpaceWeather/tests/test_methods_ace.py
@@ -21,7 +21,7 @@ class TestACEMethods(object):
         self.out = None
         return
 
-    def setup_teardown(self):
+    def teardown_method(self):
         """Clean up previous testing setup."""
         del self.out
         return
@@ -61,7 +61,7 @@ class TestACESWEPAMMethods(object):
         self.omni_keys = ['sw_proton_dens_norm', 'sw_ion_temp_norm']
         return
 
-    def setup_teardown(self):
+    def teardown_method(self):
         """Clean up previous testing setup."""
         del self.testInst
         return

--- a/pysatSpaceWeather/tests/test_methods_f107.py
+++ b/pysatSpaceWeather/tests/test_methods_f107.py
@@ -21,7 +21,7 @@ from pysatSpaceWeather.instruments import sw_f107
 class TestSWF107(object):
     """Test class for F10.7 methods."""
 
-    def setup(self):
+    def setup_method(self):
         """Create a clean testing setup."""
         # Load a test instrument
         self.testInst = pysat.Instrument()
@@ -31,7 +31,7 @@ class TestSWF107(object):
                                                   for i in range(160)])
         return
 
-    def teardown(self):
+    def setup_teardown(self):
         """Clean up previous testing setup."""
         del self.testInst
         return
@@ -123,7 +123,7 @@ class TestSWF107(object):
 class TestSWF107Combine(object):
     """Test class for the `combine_f107` method."""
 
-    def setup(self):
+    def setup_method(self):
         """Create a clean testing setup."""
         # Switch to test_data directory
         self.saved_path = pysat.params['data_dirs']
@@ -142,7 +142,7 @@ class TestSWF107Combine(object):
 
         return
 
-    def teardown(self):
+    def setup_teardown(self):
         """Clean up previous testing setup."""
         pysat.params.data['data_dirs'] = self.saved_path
         del self.combine_inst, self.test_day, self.combine_times

--- a/pysatSpaceWeather/tests/test_methods_f107.py
+++ b/pysatSpaceWeather/tests/test_methods_f107.py
@@ -31,7 +31,7 @@ class TestSWF107(object):
                                                   for i in range(160)])
         return
 
-    def setup_teardown(self):
+    def teardown_method(self):
         """Clean up previous testing setup."""
         del self.testInst
         return
@@ -142,7 +142,7 @@ class TestSWF107Combine(object):
 
         return
 
-    def setup_teardown(self):
+    def teardown_method(self):
         """Clean up previous testing setup."""
         pysat.params.data['data_dirs'] = self.saved_path
         del self.combine_inst, self.test_day, self.combine_times

--- a/pysatSpaceWeather/tests/test_methods_general.py
+++ b/pysatSpaceWeather/tests/test_methods_general.py
@@ -18,13 +18,13 @@ from pysatSpaceWeather.instruments.methods import general
 class TestGeneralMethods(object):
     """Test class for general methods."""
 
-    def setup(self):
+    def setup_method(self):
         """Create a clean testing setup."""
         self.testInst = pysat.Instrument('pysat', 'testing', use_header=True)
         self.testInst.load(date=self.testInst.inst_module._test_dates[''][''])
         return
 
-    def teardown(self):
+    def teardown_method(self):
         """Clean up previous testing setup."""
         del self.testInst
         return

--- a/pysatSpaceWeather/tests/test_methods_general.py
+++ b/pysatSpaceWeather/tests/test_methods_general.py
@@ -20,7 +20,7 @@ class TestGeneralMethods(object):
 
     def setup(self):
         """Create a clean testing setup."""
-        self.testInst = pysat.Instrument('pysat', 'testing')
+        self.testInst = pysat.Instrument('pysat', 'testing', use_header=True)
         self.testInst.load(date=self.testInst.inst_module._test_dates[''][''])
         return
 

--- a/pysatSpaceWeather/tests/test_methods_kp.py
+++ b/pysatSpaceWeather/tests/test_methods_kp.py
@@ -21,7 +21,7 @@ from pysatSpaceWeather.instruments import sw_kp
 class TestSWKp(object):
     """Test class for Kp methods."""
 
-    def setup(self):
+    def setup_method(self):
         """Create a clean testing setup."""
         # Load a test instrument
         self.testInst = pysat.Instrument('pysat', 'testing', num_samples=12,
@@ -50,7 +50,7 @@ class TestSWKp(object):
         self.testMeta = pysat.Meta()
         return
 
-    def teardown(self):
+    def setup_teardown(self):
         """Clean up previous testing setup."""
         del self.testInst, self.testMeta, self.test_time
         return
@@ -274,7 +274,7 @@ class TestSWKp(object):
 class TestSwKpCombine(object):
     """Tests for the `combine_kp` method."""
 
-    def setup(self):
+    def setup_method(self):
         """Create a clean testing setup."""
         # Switch to test_data directory
         self.saved_path = pysat.params['data_dirs']
@@ -302,7 +302,7 @@ class TestSwKpCombine(object):
 
         return
 
-    def teardown(self):
+    def setup_teardown(self):
         """Clean up previous testing."""
         pysat.params.data['data_dirs'] = self.saved_path
         del self.combine, self.test_day, self.saved_path, self.load_kwargs
@@ -472,7 +472,7 @@ class TestSwKpCombine(object):
 class TestSWAp(object):
     """Test class for Ap methods."""
 
-    def setup(self):
+    def setup_method(self):
         """Create a clean testing setup."""
         self.testInst = pysat.Instrument('pysat', 'testing', num_samples=10,
                                          use_header=True)
@@ -499,7 +499,7 @@ class TestSWAp(object):
             self.testInst.meta.labels.notes: 'test ap'}
         return
 
-    def teardown(self):
+    def setup_teardown(self):
         """Clean up previous testing."""
         del self.testInst, self.test_time
         return

--- a/pysatSpaceWeather/tests/test_methods_kp.py
+++ b/pysatSpaceWeather/tests/test_methods_kp.py
@@ -24,7 +24,8 @@ class TestSWKp(object):
     def setup(self):
         """Create a clean testing setup."""
         # Load a test instrument
-        self.testInst = pysat.Instrument('pysat', 'testing', num_samples=12)
+        self.testInst = pysat.Instrument('pysat', 'testing', num_samples=12,
+                                         use_header=True)
         self.test_time = pysat.instruments.pysat_testing._test_dates['']['']
 
         load_kwargs = {'date': self.test_time}
@@ -283,13 +284,15 @@ class TestSwKpCombine(object):
         self.test_day = dt.datetime(2019, 3, 18)
         self.combine = {"standard_inst": pysat.Instrument(inst_module=sw_kp,
                                                           tag="",
-                                                          update_files=True),
+                                                          update_files=True,
+                                                          use_header=True),
                         "recent_inst": pysat.Instrument(inst_module=sw_kp,
                                                         tag="recent",
-                                                        update_files=True),
+                                                        update_files=True,
+                                                        use_header=True),
                         "forecast_inst":
-                        pysat.Instrument(inst_module=sw_kp,
-                                         tag="forecast", update_files=True),
+                        pysat.Instrument(inst_module=sw_kp, tag="forecast",
+                                         update_files=True, use_header=True),
                         "start": self.test_day - dt.timedelta(days=30),
                         "stop": self.test_day + dt.timedelta(days=3),
                         "fill_val": -1}
@@ -471,7 +474,8 @@ class TestSWAp(object):
 
     def setup(self):
         """Create a clean testing setup."""
-        self.testInst = pysat.Instrument('pysat', 'testing', num_samples=10)
+        self.testInst = pysat.Instrument('pysat', 'testing', num_samples=10,
+                                         use_header=True)
         self.test_time = pysat.instruments.pysat_testing._test_dates['']['']
 
         load_kwargs = {'date': self.test_time}

--- a/pysatSpaceWeather/tests/test_methods_kp.py
+++ b/pysatSpaceWeather/tests/test_methods_kp.py
@@ -50,7 +50,7 @@ class TestSWKp(object):
         self.testMeta = pysat.Meta()
         return
 
-    def setup_teardown(self):
+    def teardown_method(self):
         """Clean up previous testing setup."""
         del self.testInst, self.testMeta, self.test_time
         return
@@ -302,7 +302,7 @@ class TestSwKpCombine(object):
 
         return
 
-    def setup_teardown(self):
+    def teardown_method(self):
         """Clean up previous testing."""
         pysat.params.data['data_dirs'] = self.saved_path
         del self.combine, self.test_day, self.saved_path, self.load_kwargs
@@ -499,7 +499,7 @@ class TestSWAp(object):
             self.testInst.meta.labels.notes: 'test ap'}
         return
 
-    def setup_teardown(self):
+    def teardown_method(self):
         """Clean up previous testing."""
         del self.testInst, self.test_time
         return


### PR DESCRIPTION
# Description

Updates syntax to keep up with deprecations

- Updated syntax for pysat instrument testing suite
  - `_test_download_ci`
  - new testing class
  - `use_header=True`
- Remove deprecated pytest syntax (backwards support for nose)
- Removed deprecated pandas syntax (iteritems)

# Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

pytest suite

## Test Configuration
* Operating system: Mac OS Monterrey
* Version number: Python 3.8.11
* pysat develop

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the
release checklist on the pysat wiki:
https://github.com/pysat/pysat/wiki/Checklist-for-Release
