### PR TITLE
BUG: updated fill value type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 [0.1.0] - 2022-XX-XX
 --------------------
+* Bugs
+   * Fixed F10.7 prelim and daily metadata to allow the fill value to keep the
+     same type as the data
 * Maintenance
   * Updated the GitHub action version numbers
   * Updated syntax for pysat instrument testing suite

--- a/pysatSpaceWeather/instruments/sw_f107.py
+++ b/pysatSpaceWeather/instruments/sw_f107.py
@@ -237,6 +237,10 @@ def load(fnames, tag='', inst_id=''):
                 meta.labels.desc: meta['f107_adjusted', meta.labels.desc]}
 
     elif tag == 'daily' or tag == 'prelim':
+        # Update the allowed types for the fill value
+        meta.labels.label_type['fill_val'] = (float, int, np.float64,
+                                              np.int64, str)
+
         meta['ssn'] = {meta.labels.units: '',
                        meta.labels.name: 'Sunspot Number',
                        meta.labels.notes: '',


### PR DESCRIPTION
# Description

Updated the allowed fill value types for F10.7 'daily' and 'prelim' metadata. Addresses #91.

# Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

```
import pysat

f107 = pysat.Instrument('sw', 'f107', tag='prelim')

f107.load(2014, 25, use_header=True)
f107['goes_bgd_flux']
```

Yeilds:
```
2014-01-25    *
Name: goes_bgd_flux, dtype: object
```

And no warnings are raised.

## Test Configuration
* Operating system: OS X Big Sur
* Version number: Python 3.8
* Any details about your local setup that are relevant: develop branch of pysat

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the
release checklist on the pysat wiki:
https://github.com/pysat/pysat/wiki/Checklist-for-Release
