### PR TITLE
LASP auroral index prediction data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,10 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 * Enhancements
   * Changed downloads to write files across multiple Instruments, when the
     remote files contain a mix of data products
-  * Added new instruments: sw_ap, sw_apo, sw_cp, sw_flare, sw_hpo, sw_polar-cap,
-    sw_sbfield, sw_ssn, and sw_storm-prob
+  * Added new instruments: sw_ae, sw_al, sw_au, sw_ap, sw_apo, sw_cp, sw_flare,
+    sw_hpo, sw_polar-cap, sw_sbfield, sw_ssn, and sw_storm-prob
   * Added new data sources (tag 'now') for the F10.7 from GFZ
-  * Created a general download routine for the GFZ data
+  * Created a general download routine for the GFZ and LASP data
   * Added new examples to the documentation
 
 [0.0.9] - 2022-12-21

--- a/docs/supported_instruments.rst
+++ b/docs/supported_instruments.rst
@@ -78,6 +78,53 @@ by :py:class:`pysat.Instrument` and saved into appropriate files.  For example,
 the definitive Kp data from the German Research Centre for Geosciences at
 Potsdam (GFZ) will also download Ap and Cp data files.
 
+.. _sw-ae-inst:
+
+AE
+^^^
+
+AE is an auroral electrojet index that reflects the level of magnetic deflection
+in the auroral zone, due to the difference between the eastward and westward
+electroject currents at Earth.  Real-time predictions (last 96 hours) are
+provided by
+`LASP <https://lasp.colorado.edu/space_weather/dsttemerin/dsttemerin.html>`_.
+
+
+.. automodule:: pysatSpaceWeather.instruments.sw_ae
+   :members:
+
+
+.. _sw-al-inst:
+
+
+AL
+^^^
+
+AL is an auroral electrojet index that reflects the lower envelope, the negative
+peak of the electroject currents at Earth.  Real-time predictions (last 96
+hours) are provided by
+`LASP <https://lasp.colorado.edu/space_weather/dsttemerin/dsttemerin.html>`_.
+
+
+.. automodule:: pysatSpaceWeather.instruments.sw_al
+   :members:
+
+
+.. _sw-al-inst:
+
+
+AU
+^^^
+
+AU is an auroral electrojet index that reflects the upper envelope, the positive
+peak of the electroject currents at Earth.  Real-time predictions (last 96
+hours) are provided by
+`LASP <https://lasp.colorado.edu/space_weather/dsttemerin/dsttemerin.html>`_.
+
+
+.. automodule:: pysatSpaceWeather.instruments.sw_au
+   :members:
+
 
 .. _sw-ap-inst:
 

--- a/pysatSpaceWeather/instruments/__init__.py
+++ b/pysatSpaceWeather/instruments/__init__.py
@@ -1,8 +1,8 @@
 from pysatSpaceWeather.instruments import methods  # noqa F401
 
-__all__ = ['ace_epam', 'ace_mag', 'ace_sis', 'ace_swepam', 'sw_mgii',
-           'sw_ap', 'sw_apo', 'sw_cp', 'sw_dst', 'sw_f107', 'sw_flare',
-           'sw_hpo', 'sw_kp', 'sw_polarcap', 'sw_sbfield', 'sw_ssn',
+__all__ = ['ace_epam', 'ace_mag', 'ace_sis', 'ace_swepam', 'sw_ae', 'sw_al',
+           'sw_au', 'sw_ap', 'sw_apo', 'sw_cp', 'sw_dst', 'sw_f107', 'sw_flare',
+           'sw_hpo', 'sw_kp', 'sw_mgii', 'sw_polarcap', 'sw_sbfield', 'sw_ssn',
            'sw_stormprob']
 
 for inst in __all__:

--- a/pysatSpaceWeather/instruments/methods/__init__.py
+++ b/pysatSpaceWeather/instruments/methods/__init__.py
@@ -1,8 +1,10 @@
 from pysatSpaceWeather.instruments.methods import ace  # noqa F401
+from pysatSpaceWeather.instruments.methods import auroral_electrojet  # noqa F401
 from pysatSpaceWeather.instruments.methods import dst  # noqa F401
 from pysatSpaceWeather.instruments.methods import f107  # noqa F401
 from pysatSpaceWeather.instruments.methods import general  # noqa F401
 from pysatSpaceWeather.instruments.methods import gfz  # noqa F401
 from pysatSpaceWeather.instruments.methods import kp_ap  # noqa F401
+from pysatSpaceWeather.instruments.methods import lasp  # noqa F401
 from pysatSpaceWeather.instruments.methods import lisird # noqa F401
 from pysatSpaceWeather.instruments.methods import swpc  # noqa F401

--- a/pysatSpaceWeather/instruments/methods/auroral_electrojet.py
+++ b/pysatSpaceWeather/instruments/methods/auroral_electrojet.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-.
+"""Provides support routines for auroral electrojet indices."""
+
+
+def acknowledgements(name, tag):
+    """Define the acknowledgements for the index and data source.
+
+    Parameters
+    ----------
+    name : str
+        Name of the auroral electrojet index
+    tag : str
+        Tag of the auroral electrojet index
+
+    Returns
+    -------
+    ackn : str
+        Acknowledgements string associated with the appropriate auroral
+        electrojet tag.
+
+    """
+
+    ackn = {'lasp': ''.join(['Preliminary ', name.upper(), ' predictions are ',
+                             'provided by LASP, contact Xinlin Li for more ',
+                             'details <xinlin.li@lasp.colorado.edu>'])}
+
+    return ackn[tag]
+
+
+def references(name, tag):
+    """Define the references for the auroral electrojet data.
+
+    Parameters
+    ----------
+    name : str
+        Name of the auroral electrojet index
+    tag : string
+        Tag of the space weather index
+
+    Returns
+    -------
+    refs : str
+        Reference string associated with the appropriate Dst tag.
+
+    """
+
+    davis = ''.join(['Davis, T. N., and Sugiura, M. (1966), Auroral electrojet',
+                     ' activity index AE and its universal time variations, ',
+                     'J. Geophys. Res., 71( 3), 785– 801, ',
+                     'doi:10.1029/JZ071i003p00785.'])
+
+    luo_au_al_ae = ''.join(['Luo, B., Li, X., Temerin, M., and Liu, S. (2013),',
+                            'Prediction of the AU, AL, and AE indices using ',
+                            'solar wind parameters, J. Geophys. Res. Space ',
+                            'Physics, 118, 7683– 7694, ',
+                            'doi:10.1002/2013JA019188.'])
+    li_al = ''.join(['Li, X., Oh, K. S., and Temerin, M. (2007), Prediction ',
+                     'of the AL index using solar wind parameters, J. ',
+                     'Geophys. Res., 112, A06224, doi:10.1029/2006JA011918.'])
+
+    refs = {'lasp': {'ae': '\n'.join([davis, luo_au_al_ae]),
+                     'au': '\n'.join([davis, luo_au_al_ae]),
+                     'al': '\n'.join([davis, li_al, luo_au_al_ae])}}
+
+    return refs[tag][name]

--- a/pysatSpaceWeather/instruments/methods/lasp.py
+++ b/pysatSpaceWeather/instruments/methods/lasp.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-.
+"""Provides support routines for LASP data."""
+
+import datetime as dt
+import numpy as np
+import os
+import pandas as pds
+import requests
+
+import pysat
+
+
+def prediction_downloads(name, tag, data_path):
+    """Download LASP 96-hour prediction data.
+
+    Parameters
+    ----------
+    name : str
+        Instrument name, currently supports Dst, AL, AE, and AU.
+    tag : str
+        Instrument tag, used to create a descriptive file name.
+    data_path : str
+        Path to data directory.
+
+    Raises
+    ------
+    IOError
+        If the data link has an unexpected format
+
+    """
+
+    # Set the remote data variables
+    url = ''.join(['https://lasp.colorado.edu/space_weather/dsttemerin/',
+                   name.lower(), '_last_96_hrs.txt'])
+    times = list()
+    data_dict = {name.lower(): []}
+
+    # Download the webpage
+    req = requests.get(url)
+
+    # Test to see if the file was found on the server
+    if req.text.find('not found on this server') > 0:
+        pysat.logger.warning(''.join(['LASP last 96 hour Dst file not ',
+                                      'found on server: ', url]))
+    else:
+        # Split the file into lines, removing the header and
+        # trailing empty line
+        file_lines = req.text.split('\n')[1:-1]
+
+        # Format the data
+        for line in file_lines:
+            # Split the line on whitespace
+            line_cols = line.split()
+
+            if len(line_cols) != 2:
+                raise IOError(''.join(['unexpected line encountered in file ',
+                                       'retrieved from ', url, ':\n', line]))
+
+            # Format the time and AL values
+            times.append(dt.datetime.strptime(line_cols[0], '%Y/%j-%H:%M:%S'))
+            data_dict[name.lower()].append(np.float64(line_cols[1]))
+
+    # Re-cast the data as a pandas DataFrame
+    data = pds.DataFrame(data_dict, index=times)
+
+    # Write out as a file
+    file_base = '_'.join(['sw', name, tag,
+                          pysat.utils.time.today().strftime('%Y-%m-%d')])
+    file_name = os.path.join(data_path, '{:s}.txt'.format(file_base))
+    data.to_csv(file_name)
+
+    return

--- a/pysatSpaceWeather/instruments/sw_ae.py
+++ b/pysatSpaceWeather/instruments/sw_ae.py
@@ -6,9 +6,9 @@ Properties
 platform
     'sw'
 name
-    'al'
+    'ae'
 tag
-    - 'lasp' Predicted Dst from real-time ACE or DSCOVR provided by LASP
+    - 'lasp' Predicted AE from real-time ACE or DSCOVR provided by LASP
 inst_id
     - ''
 
@@ -104,7 +104,7 @@ def load(fnames, tag='', inst_id=''):
 
 
 def list_files(tag='', inst_id='', data_path='', format_str=None):
-    """List local data files for Dst data.
+    """List local data files for AE data.
 
     Parameters
     ----------

--- a/pysatSpaceWeather/instruments/sw_ae.py
+++ b/pysatSpaceWeather/instruments/sw_ae.py
@@ -1,0 +1,168 @@
+# -*- coding: utf-8 -*-
+"""Supports the auroral electrojet AE values.
+
+Properties
+----------
+platform
+    'sw'
+name
+    'al'
+tag
+    - 'lasp' Predicted Dst from real-time ACE or DSCOVR provided by LASP
+inst_id
+    - ''
+
+"""
+
+import datetime as dt
+import numpy as np
+
+import pysat
+
+from pysatSpaceWeather.instruments.methods import auroral_electrojet as mm_ae
+from pysatSpaceWeather.instruments.methods import lasp
+
+# ----------------------------------------------------------------------------
+# Instrument attributes
+
+platform = 'sw'
+name = 'al'
+tags = {'lasp': 'Predicted AE from real-time ACE or DSCOVR provided by LASP'}
+inst_ids = {'': [tag for tag in tags.keys()]}
+
+# Generate today's date to support loading predicted data sets
+today = pysat.utils.time.today()
+tomorrow = today + dt.timedelta(days=1)
+
+# ----------------------------------------------------------------------------
+# Instrument test attributes
+
+_test_dates = {'': {'lasp': today}}
+
+# ----------------------------------------------------------------------------
+# Instrument methods
+
+
+def init(self):
+    """Initialize the Instrument object with instrument specific values."""
+
+    self.acknowledgements = mm_ae.acknowledgements(self.name, self.tag)
+    self.references = mm_ae.references(self.name, self.tag)
+    pysat.logger.info(self.acknowledgements)
+    return
+
+
+def clean(self):
+    """Clean the AE index, empty function."""
+    return
+
+
+# ----------------------------------------------------------------------------
+# Instrument functions
+
+
+def load(fnames, tag='', inst_id=''):
+    """Load the AE index files.
+
+    Parameters
+    ----------
+    fnames : pandas.Series
+        Series of filenames
+    tag : str
+        Instrument tag string. (default='')
+    inst_id : str
+        Instrument ID, not used. (default='')
+
+    Returns
+    -------
+    data : pandas.DataFrame
+        Object containing satellite data
+    pysat.Meta
+        Object containing metadata such as column names and units
+
+    Note
+    ----
+    Called by pysat. Not intended for direct use by user.
+
+    """
+    data = pysat.instruments.methods.general.load_csv_data(
+        fnames, read_csv_kwargs={'index_col': 0, 'parse_dates': True})
+
+    # Create metadata
+    meta = pysat.Meta()
+    meta['ae'] = {meta.labels.units: 'nT',
+                  meta.labels.name: 'AE',
+                  meta.labels.notes: tags[tag],
+                  meta.labels.desc: ''.join([
+                      'Auroral Electrojet index, best estimate ',
+                      'of the average value over the next two hours']),
+                  meta.labels.fill_val: np.nan,
+                  meta.labels.min_val: -np.inf,
+                  meta.labels.max_val: np.inf}
+
+    return data, meta
+
+
+def list_files(tag='', inst_id='', data_path='', format_str=None):
+    """List local data files for Dst data.
+
+    Parameters
+    ----------
+    tag : str
+        Instrument tag, accepts any value from `tags`. (default='')
+    inst_id : str
+        Instrument ID, not used. (default='')
+    data_path : str
+        Path to data directory. (default='')
+    format_str : str or NoneType
+        User specified file format.  If None is specified, the default
+        formats associated with the supplied tags are used. (default=None)
+
+    Returns
+    -------
+    files : pysat.Files
+        A class containing the verified available files
+
+    Note
+    ----
+    Called by pysat. Not intended for direct use by user.
+
+    """
+    # Get the format string, if not supplied by the user
+    if format_str is None:
+        format_str = ''.join(['sw_ae_', tag, '_{year:4d}-{month:2d}-',
+                              '{day:2d}.txt'])
+
+    # Get the desired files
+    files = pysat.Files.from_os(data_path=data_path, format_str=format_str)
+
+    return files
+
+
+def download(date_array, tag, inst_id, data_path):
+    """Download the AE index data from the appropriate repository.
+
+    Parameters
+    ----------
+    date_array : array-like or pandas.DatetimeIndex
+        Array-like or index of datetimes for which files will be downloaded.
+    tag : str
+        Instrument tag, used to determine download location.
+    inst_id : str
+        Instrument ID, not used.
+    data_path : str
+        Path to data directory.
+
+    Raises
+    ------
+    IOError
+        If the data link has an unexpected format
+
+    Note
+    ----
+    Called by pysat. Not intended for direct use by user.
+
+    """
+    lasp.prediction_downloads(name, tag, data_path)
+
+    return

--- a/pysatSpaceWeather/instruments/sw_ae.py
+++ b/pysatSpaceWeather/instruments/sw_ae.py
@@ -26,7 +26,7 @@ from pysatSpaceWeather.instruments.methods import lasp
 # Instrument attributes
 
 platform = 'sw'
-name = 'al'
+name = 'ae'
 tags = {'lasp': 'Predicted AE from real-time ACE or DSCOVR provided by LASP'}
 inst_ids = {'': [tag for tag in tags.keys()]}
 

--- a/pysatSpaceWeather/instruments/sw_al.py
+++ b/pysatSpaceWeather/instruments/sw_al.py
@@ -1,0 +1,168 @@
+# -*- coding: utf-8 -*-
+"""Supports the auroral electrojet AL values.
+
+Properties
+----------
+platform
+    'sw'
+name
+    'al'
+tag
+    - 'lasp' Predicted Dst from real-time ACE or DSCOVR provided by LASP
+inst_id
+    - ''
+
+"""
+
+import datetime as dt
+import numpy as np
+
+import pysat
+
+from pysatSpaceWeather.instruments.methods import auroral_electrojet as mm_ae
+from pysatSpaceWeather.instruments.methods import lasp
+
+# ----------------------------------------------------------------------------
+# Instrument attributes
+
+platform = 'sw'
+name = 'al'
+tags = {'lasp': 'Predicted AL from real-time ACE or DSCOVR provided by LASP'}
+inst_ids = {'': [tag for tag in tags.keys()]}
+
+# Generate today's date to support loading predicted data sets
+today = pysat.utils.time.today()
+tomorrow = today + dt.timedelta(days=1)
+
+# ----------------------------------------------------------------------------
+# Instrument test attributes
+
+_test_dates = {'': {'lasp': today}}
+
+# ----------------------------------------------------------------------------
+# Instrument methods
+
+
+def init(self):
+    """Initialize the Instrument object with instrument specific values."""
+
+    self.acknowledgements = mm_ae.acknowledgements(self.name, self.tag)
+    self.references = mm_ae.references(self.name, self.tag)
+    pysat.logger.info(self.acknowledgements)
+    return
+
+
+def clean(self):
+    """Clean the AL index, empty function."""
+    return
+
+
+# ----------------------------------------------------------------------------
+# Instrument functions
+
+
+def load(fnames, tag='', inst_id=''):
+    """Load the AL index files.
+
+    Parameters
+    ----------
+    fnames : pandas.Series
+        Series of filenames
+    tag : str
+        Instrument tag string. (default='')
+    inst_id : str
+        Instrument ID, not used. (default='')
+
+    Returns
+    -------
+    data : pandas.DataFrame
+        Object containing satellite data
+    pysat.Meta
+        Object containing metadata such as column names and units
+
+    Note
+    ----
+    Called by pysat. Not intended for direct use by user.
+
+    """
+    data = pysat.instruments.methods.general.load_csv_data(
+        fnames, read_csv_kwargs={'index_col': 0, 'parse_dates': True})
+
+    # Create metadata
+    meta = pysat.Meta()
+    meta['al'] = {meta.labels.units: 'nT',
+                  meta.labels.name: 'AL',
+                  meta.labels.notes: tags[tag],
+                  meta.labels.desc: ''.join([
+                      'Auroral Electrojet lower envelope, best estimate ',
+                      'of the average value over the next two hours']),
+                  meta.labels.fill_val: np.nan,
+                  meta.labels.min_val: -np.inf,
+                  meta.labels.max_val: 0.0}
+
+    return data, meta
+
+
+def list_files(tag='', inst_id='', data_path='', format_str=None):
+    """List local data files for Dst data.
+
+    Parameters
+    ----------
+    tag : str
+        Instrument tag, accepts any value from `tags`. (default='')
+    inst_id : str
+        Instrument ID, not used. (default='')
+    data_path : str
+        Path to data directory. (default='')
+    format_str : str or NoneType
+        User specified file format.  If None is specified, the default
+        formats associated with the supplied tags are used. (default=None)
+
+    Returns
+    -------
+    files : pysat.Files
+        A class containing the verified available files
+
+    Note
+    ----
+    Called by pysat. Not intended for direct use by user.
+
+    """
+    # Get the format string, if not supplied by the user
+    if format_str is None:
+        format_str = ''.join(['sw_al_', tag, '_{year:4d}-{month:2d}-',
+                              '{day:2d}.txt'])
+
+    # Get the desired files
+    files = pysat.Files.from_os(data_path=data_path, format_str=format_str)
+
+    return files
+
+
+def download(date_array, tag, inst_id, data_path):
+    """Download the AL index data from the appropriate repository.
+
+    Parameters
+    ----------
+    date_array : array-like or pandas.DatetimeIndex
+        Array-like or index of datetimes for which files will be downloaded.
+    tag : str
+        Instrument tag, used to determine download location.
+    inst_id : str
+        Instrument ID, not used.
+    data_path : str
+        Path to data directory.
+
+    Raises
+    ------
+    IOError
+        If the data link has an unexpected format
+
+    Note
+    ----
+    Called by pysat. Not intended for direct use by user.
+
+    """
+    lasp.prediction_downloads(name, tag, data_path)
+
+    return

--- a/pysatSpaceWeather/instruments/sw_al.py
+++ b/pysatSpaceWeather/instruments/sw_al.py
@@ -8,7 +8,7 @@ platform
 name
     'al'
 tag
-    - 'lasp' Predicted Dst from real-time ACE or DSCOVR provided by LASP
+    - 'lasp' Predicted AL from real-time ACE or DSCOVR provided by LASP
 inst_id
     - ''
 
@@ -104,7 +104,7 @@ def load(fnames, tag='', inst_id=''):
 
 
 def list_files(tag='', inst_id='', data_path='', format_str=None):
-    """List local data files for Dst data.
+    """List local data files for AL data.
 
     Parameters
     ----------

--- a/pysatSpaceWeather/instruments/sw_au.py
+++ b/pysatSpaceWeather/instruments/sw_au.py
@@ -1,0 +1,168 @@
+# -*- coding: utf-8 -*-
+"""Supports the auroral electrojet AU values.
+
+Properties
+----------
+platform
+    'sw'
+name
+    'au'
+tag
+    - 'lasp' Predicted Dst from real-time ACE or DSCOVR provided by LASP
+inst_id
+    - ''
+
+"""
+
+import datetime as dt
+import numpy as np
+
+import pysat
+
+from pysatSpaceWeather.instruments.methods import auroral_electrojet as mm_ae
+from pysatSpaceWeather.instruments.methods import lasp
+
+# ----------------------------------------------------------------------------
+# Instrument attributes
+
+platform = 'sw'
+name = 'au'
+tags = {'lasp': 'Predicted AU from real-time ACE or DSCOVR provided by LASP'}
+inst_ids = {'': [tag for tag in tags.keys()]}
+
+# Generate today's date to support loading predicted data sets
+today = pysat.utils.time.today()
+tomorrow = today + dt.timedelta(days=1)
+
+# ----------------------------------------------------------------------------
+# Instrument test attributes
+
+_test_dates = {'': {'lasp': today}}
+
+# ----------------------------------------------------------------------------
+# Instrument methods
+
+
+def init(self):
+    """Initialize the Instrument object with instrument specific values."""
+
+    self.acknowledgements = mm_ae.acknowledgements(self.name, self.tag)
+    self.references = mm_ae.references(self.name, self.tag)
+    pysat.logger.info(self.acknowledgements)
+    return
+
+
+def clean(self):
+    """Clean the AU index, empty function."""
+    return
+
+
+# ----------------------------------------------------------------------------
+# Instrument functions
+
+
+def load(fnames, tag='', inst_id=''):
+    """Load the AU index files.
+
+    Parameters
+    ----------
+    fnames : pandas.Series
+        Series of filenames
+    tag : str
+        Instrument tag string. (default='')
+    inst_id : str
+        Instrument ID, not used. (default='')
+
+    Returns
+    -------
+    data : pandas.DataFrame
+        Object containing satellite data
+    pysat.Meta
+        Object containing metadata such as column names and units
+
+    Note
+    ----
+    Called by pysat. Not intended for direct use by user.
+
+    """
+    data = pysat.instruments.methods.general.load_csv_data(
+        fnames, read_csv_kwargs={'index_col': 0, 'parse_dates': True})
+
+    # Create metadata
+    meta = pysat.Meta()
+    meta['au'] = {meta.labels.units: 'nT',
+                  meta.labels.name: 'AU',
+                  meta.labels.notes: tags[tag],
+                  meta.labels.desc: ''.join([
+                      'Auroral Electrojet upper envelope, best estimate ',
+                      'of the average value over the next two hours']),
+                  meta.labels.fill_val: np.nan,
+                  meta.labels.min_val: 0.0,
+                  meta.labels.max_val: np.inf}
+
+    return data, meta
+
+
+def list_files(tag='', inst_id='', data_path='', format_str=None):
+    """List local data files for Dst data.
+
+    Parameters
+    ----------
+    tag : str
+        Instrument tag, accepts any value from `tags`. (default='')
+    inst_id : str
+        Instrument ID, not used. (default='')
+    data_path : str
+        Path to data directory. (default='')
+    format_str : str or NoneType
+        User specified file format.  If None is specified, the default
+        formats associated with the supplied tags are used. (default=None)
+
+    Returns
+    -------
+    files : pysat.Files
+        A class containing the verified available files
+
+    Note
+    ----
+    Called by pysat. Not intended for direct use by user.
+
+    """
+    # Get the format string, if not supplied by the user
+    if format_str is None:
+        format_str = ''.join(['sw_au_', tag, '_{year:4d}-{month:2d}-',
+                              '{day:2d}.txt'])
+
+    # Get the desired files
+    files = pysat.Files.from_os(data_path=data_path, format_str=format_str)
+
+    return files
+
+
+def download(date_array, tag, inst_id, data_path):
+    """Download the AU index data from the appropriate repository.
+
+    Parameters
+    ----------
+    date_array : array-like or pandas.DatetimeIndex
+        Array-like or index of datetimes for which files will be downloaded.
+    tag : str
+        Instrument tag, used to determine download location.
+    inst_id : str
+        Instrument ID, not used.
+    data_path : str
+        Path to data directory.
+
+    Raises
+    ------
+    IOError
+        If the data link has an unexpected format
+
+    Note
+    ----
+    Called by pysat. Not intended for direct use by user.
+
+    """
+    lasp.prediction_downloads(name, tag, data_path)
+
+    return

--- a/pysatSpaceWeather/instruments/sw_au.py
+++ b/pysatSpaceWeather/instruments/sw_au.py
@@ -8,7 +8,7 @@ platform
 name
     'au'
 tag
-    - 'lasp' Predicted Dst from real-time ACE or DSCOVR provided by LASP
+    - 'lasp' Predicted AU from real-time ACE or DSCOVR provided by LASP
 inst_id
     - ''
 
@@ -104,7 +104,7 @@ def load(fnames, tag='', inst_id=''):
 
 
 def list_files(tag='', inst_id='', data_path='', format_str=None):
-    """List local data files for Dst data.
+    """List local data files for AU data.
 
     Parameters
     ----------

--- a/pysatSpaceWeather/instruments/sw_dst.py
+++ b/pysatSpaceWeather/instruments/sw_dst.py
@@ -36,6 +36,7 @@ import requests
 import pysat
 
 from pysatSpaceWeather.instruments.methods import dst as mm_dst
+from pysatSpaceWeather.instruments.methods import lasp
 
 # ----------------------------------------------------------------------------
 # Instrument attributes
@@ -289,45 +290,6 @@ def download(date_array, tag, inst_id, data_path):
 
         ftp.close()
     elif tag == 'lasp':
-        # Set the remote data variables
-        url = ''.join(['https://lasp.colorado.edu/space_weather/dsttemerin/',
-                       'dst_last_96_hrs.txt'])
-        times = list()
-        data_dict = {'dst': []}
-
-        # Download the webpage
-        req = requests.get(url)
-
-        # Test to see if the file was found on the server
-        if req.text.find('not found on this server') > 0:
-            pysat.logger.warning(''.join(['LASP last 96 hour Dst file not ',
-                                          'found on server: ', url]))
-        else:
-            # Split the file into lines, removing the header and
-            # trailing empty line
-            file_lines = req.text.split('\n')[1:-1]
-
-            # Format the data
-            for line in file_lines:
-                # Split the line on whitespace
-                line_cols = line.split()
-
-                if len(line_cols) != 2:
-                    raise IOError(''.join(['unexpected line encountered in ',
-                                           'file retrieved from ', url, ':\n',
-                                           line]))
-
-                # Format the time and Dst values
-                times.append(dt.datetime.strptime(line_cols[0],
-                                                  '%Y/%j-%H:%M:%S'))
-                data_dict['dst'].append(np.float64(line_cols[1]))
-
-        # Re-cast the data as a pandas DataFrame
-        data = pds.DataFrame(data_dict, index=times)
-
-        # Write out as a file
-        file_base = '_'.join(['sw', 'dst', tag, today.strftime('%Y-%m-%d')])
-        file_name = os.path.join(data_path, '{:s}.txt'.format(file_base))
-        data.to_csv(file_name)
+        lasp.prediction_downloads(name, tag, data_path)
 
     return

--- a/pysatSpaceWeather/instruments/sw_dst.py
+++ b/pysatSpaceWeather/instruments/sw_dst.py
@@ -31,7 +31,6 @@ import ftplib
 import numpy as np
 import os
 import pandas as pds
-import requests
 
 import pysat
 

--- a/pysatSpaceWeather/tests/test_methods_ae.py
+++ b/pysatSpaceWeather/tests/test_methods_ae.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+# Full license can be found in License.md
+# Full author list can be found in .zenodo.json file
+# DOI:10.5281/zenodo.3986138
+# ----------------------------------------------------------------------------
+"""Integration and unit test suite for AE methods."""
+
+import pytest
+
+from pysatSpaceWeather.instruments.methods import auroral_electrojet as mm_ae
+
+
+class TestAEMethods(object):
+    """Test class for the auroral electrojet methods."""
+
+    def setup_method(self):
+        """Create a clean testing setup."""
+        self.out = None
+        return
+
+    def teardown_method(self):
+        """Clean up previous testing setup."""
+        del self.out
+        return
+
+    @pytest.mark.parametrize('name', ['ae', 'al', 'au'])
+    def test_acknowledgements(self, name):
+        """Test the auroral electrojet acknowledgements.
+
+        Parameters
+        ----------
+        name : str
+            Instrument name
+
+        """
+        self.out = mm_ae.acknowledgements(name, 'lasp')
+        assert self.out.find(name.upper()) >= 0
+        return
+
+    @pytest.mark.parametrize('name', ['ae', 'al', 'au'])
+    def test_references(self, name):
+        """Test the references for an AE instrument.
+
+        Parameters
+        ----------
+        name : str
+            Instrument name
+
+        """
+        self.out = mm_ae.references(name, 'lasp')
+        assert self.out.find('Davis, T. N.') >= 0
+        return


### PR DESCRIPTION
# Description

Addresses #70 by adding the remaining prediction data sets.

# Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

```
import pysat
import pysatSpaceWeather as py_sw

al = pysat.Instrument(inst_module=py_sw.instruments.sw_al, tag='lasp', use_header=True)
al.download()  # always get the current data for today's date
al.load(date=pysat.utils.time.today())

print(al)
```

Will have a time series with the desired auroral electrojet index (AL, AU, and AE were all added).

## Test Configuration
* Operating system: OS X Big Sur
* Version number: Python 3.9
* Any details about your local setup that are relevant

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the
release checklist on the pysat wiki:
https://github.com/pysat/pysat/wiki/Checklist-for-Release
