### PR TITLE
Datetime update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   * Implemented `iloc` in pandas Series and DataFrame index access
   * Added `verify=False` to GFZ requests
   * Updated documentation links and fixed intersphinx mapping
+  * Replaced `utcnow` with `now` and the UTC timezone
 
 [0.1.0] - 2024-02-16
 --------------------

--- a/pysatSpaceWeather/instruments/ace_epam.py
+++ b/pysatSpaceWeather/instruments/ace_epam.py
@@ -68,7 +68,7 @@ tags = {'realtime': 'Real-time data from the SWPC',
 inst_ids = {inst_id: [tag for tag in tags.keys()] for inst_id in ['']}
 
 # Define today's date
-now = dt.datetime.utcnow()
+now = dt.datetime.now(tz=dt.timezone.utc)
 
 # ----------------------------------------------------------------------------
 # Instrument test attributes

--- a/pysatSpaceWeather/instruments/ace_mag.py
+++ b/pysatSpaceWeather/instruments/ace_mag.py
@@ -68,7 +68,7 @@ tags = {'realtime': 'Real-time data from the SWPC',
 inst_ids = {inst_id: [tag for tag in tags.keys()] for inst_id in ['']}
 
 # Define today's date
-now = dt.datetime.utcnow()
+now = dt.datetime.now(tz=dt.timezone.utc)
 
 # ----------------------------------------------------------------------------
 # Instrument test attributes

--- a/pysatSpaceWeather/instruments/ace_sis.py
+++ b/pysatSpaceWeather/instruments/ace_sis.py
@@ -68,7 +68,7 @@ tags = {'realtime': 'Real-time data from the SWPC',
 inst_ids = {inst_id: [tag for tag in tags.keys()] for inst_id in ['']}
 
 # Define today's date
-now = dt.datetime.utcnow()
+now = dt.datetime.now(tz=dt.timezone.utc)
 
 # ----------------------------------------------------------------------------
 # Instrument test attributes

--- a/pysatSpaceWeather/instruments/ace_swepam.py
+++ b/pysatSpaceWeather/instruments/ace_swepam.py
@@ -67,7 +67,7 @@ tags = {'realtime': 'Real-time data from the SWPC',
 inst_ids = {inst_id: [tag for tag in tags.keys()] for inst_id in ['']}
 
 # Define today's date
-now = dt.datetime.utcnow()
+now = dt.datetime.now(tz=dt.timezone.utc)
 
 # ----------------------------------------------------------------------------
 # Instrument test attributes

--- a/pysatSpaceWeather/instruments/methods/ace.py
+++ b/pysatSpaceWeather/instruments/methods/ace.py
@@ -202,7 +202,7 @@ def download(date_array, name, tag='', inst_id='', data_path='', now=None,
     """
     # Ensure now is up-to-date, if desired
     if now is None:
-        now = dt.datetime.utcnow()
+        now = dt.datetime.now(tz=dt.timezone.utc)
 
     # Define the file information for each data type and check the
     # date range

--- a/pysatSpaceWeather/instruments/sw_ap.py
+++ b/pysatSpaceWeather/instruments/sw_ap.py
@@ -89,7 +89,7 @@ tags = {'def': 'Definitive Kp data from GFZ',
 inst_ids = {'': list(tags.keys())}
 
 # Generate todays date to support loading forecast data
-now = dt.datetime.utcnow()
+now = dt.datetime.now(tz=dt.timezone.utc)
 today = dt.datetime(now.year, now.month, now.day)
 tomorrow = today + dt.timedelta(days=1)
 

--- a/pysatSpaceWeather/instruments/sw_f107.py
+++ b/pysatSpaceWeather/instruments/sw_f107.py
@@ -95,7 +95,7 @@ inst_ids = {'': [tag for tag in tags.keys() if tag != 'now'], 'obs': ['now'],
 
 # Dict keyed by inst_id that lists supported tags and a good day of test data
 # generate todays date to support loading forecast data
-now = dt.datetime.utcnow()
+now = dt.datetime.now(tz=dt.timezone.utc)
 today = dt.datetime(now.year, now.month, now.day)
 tomorrow = today + dt.timedelta(days=1)
 

--- a/pysatSpaceWeather/instruments/sw_flare.py
+++ b/pysatSpaceWeather/instruments/sw_flare.py
@@ -74,7 +74,7 @@ inst_ids = {'': [tag for tag in tags.keys()]}
 
 # Dict keyed by inst_id that lists supported tags and a good day of test data
 # generate todays date to support loading forecast data
-now = dt.datetime.utcnow()
+now = dt.datetime.now(tz=dt.timezone.utc)
 today = dt.datetime(now.year, now.month, now.day)
 tomorrow = today + dt.timedelta(days=1)
 

--- a/pysatSpaceWeather/instruments/sw_kp.py
+++ b/pysatSpaceWeather/instruments/sw_kp.py
@@ -89,7 +89,7 @@ tags = {'': 'Deprecated, mixed definitive and nowcast Kp data from GFZ',
 inst_ids = {'': list(tags.keys())}
 
 # Generate todays date to support loading forecast data
-now = dt.datetime.utcnow()
+now = dt.datetime.now(tz=dt.timezone.utc)
 today = dt.datetime(now.year, now.month, now.day)
 
 # ----------------------------------------------------------------------------

--- a/pysatSpaceWeather/instruments/sw_mgii.py
+++ b/pysatSpaceWeather/instruments/sw_mgii.py
@@ -55,7 +55,7 @@ inst_ids = {'': [tag for tag in tags.keys()]}
 
 # Dict keyed by inst_id that lists supported tags and a good day of test data
 # generate todays date to support loading forecast data
-now = dt.datetime.utcnow()
+now = dt.datetime.now(tz=dt.timezone.utc)
 today = dt.datetime(now.year, now.month, now.day)
 tomorrow = today + pds.DateOffset(days=1)
 

--- a/pysatSpaceWeather/instruments/sw_polarcap.py
+++ b/pysatSpaceWeather/instruments/sw_polarcap.py
@@ -69,7 +69,7 @@ tags = {'prediction': 'SWPC Predictions for the next three days'}
 inst_ids = {'': list(tags.keys())}
 
 # Generate todays date to support loading forecast data
-now = dt.datetime.utcnow()
+now = dt.datetime.now(tz=dt.timezone.utc)
 today = dt.datetime(now.year, now.month, now.day)
 tomorrow = today + dt.timedelta(days=1)
 

--- a/pysatSpaceWeather/instruments/sw_sbfield.py
+++ b/pysatSpaceWeather/instruments/sw_sbfield.py
@@ -52,7 +52,7 @@ inst_ids = {'': [tag for tag in tags.keys()]}
 
 # Dict keyed by inst_id that lists supported tags and a good day of test data
 # generate todays date to support loading forecast data
-now = dt.datetime.utcnow()
+now = dt.datetime.now(tz=dt.timezone.utc)
 today = dt.datetime(now.year, now.month, now.day)
 tomorrow = today + pds.DateOffset(days=1)
 

--- a/pysatSpaceWeather/instruments/sw_ssn.py
+++ b/pysatSpaceWeather/instruments/sw_ssn.py
@@ -55,7 +55,7 @@ inst_ids = {'': [tag for tag in tags.keys()]}
 
 # Dict keyed by inst_id that lists supported tags and a good day of test data
 # generate todays date to support loading forecast data
-now = dt.datetime.utcnow()
+now = dt.datetime.now(tz=dt.timezone.utc)
 today = dt.datetime(now.year, now.month, now.day)
 tomorrow = today + pds.DateOffset(days=1)
 

--- a/pysatSpaceWeather/instruments/sw_stormprob.py
+++ b/pysatSpaceWeather/instruments/sw_stormprob.py
@@ -70,7 +70,7 @@ tags = {'forecast': 'SWPC Forecast data next (3 days)',
 inst_ids = {'': list(tags.keys())}
 
 # Generate todays date to support loading forecast data
-now = dt.datetime.utcnow()
+now = dt.datetime.now(tz=dt.timezone.utc)
 today = dt.datetime(now.year, now.month, now.day)
 tomorrow = today + dt.timedelta(days=1)
 

--- a/pysatSpaceWeather/tests/test_methods_gfz.py
+++ b/pysatSpaceWeather/tests/test_methods_gfz.py
@@ -40,7 +40,8 @@ class TestGFZMethods(object):
         """Test the download doesn't work for an incorrect Instrument."""
         with pytest.raises(ValueError) as verr:
             gfz.kp_ap_cp_download('platform', 'name', 'tag', 'inst_id',
-                                  [dt.datetime.utcnow()], 'data/path')
+                                  [dt.datetime.now(tz=dt.timezone.utc)],
+                                  'data/path')
 
         assert str(verr).find('Unknown Instrument module') >= 0
         return


### PR DESCRIPTION
# Description

Addresses #143 by replacing `utcnow` with `now` calls.

# Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Ran unit tests locally

## Test Configuration
* Operating system: OS X Big Sur
* Version number: Python 3.10
* Any details about your local setup that are relevant: develop branch of pysat

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the
release checklist on the pysat wiki:
https://github.com/pysat/pysat/wiki/Checklist-for-Release
