### PR TITLE
Bugfixes: file reading and downloads

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,19 +16,19 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.10", "3.13"]
         numpy_ver: ["latest"]
         test_config: ["latest"]
         include:
           # NEP29 compliance settings
-          - python-version: "3.10"
-            numpy_ver: "1.24"
+          - python-version: "3.11"
+            numpy_ver: "2.0"
             os: ubuntu-latest
             test_config: "NEP29"
           # Operational compliance settings
-          - python-version: "3.9"
-            numpy_ver: "1.23.5"
-            os: "ubuntu-20.04"
+          - python-version: "3.12"
+            numpy_ver: "2.0"
+            os: "ubuntu-latest"
             test_config: "Ops"
 
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }} with numpy ${{ matrix.numpy_ver }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Change Log
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
-[0.2.2] - 2025-10-07
+[0.2.2] - 2025-10-XX
 --------------------
 * Bugs
   * Fixed the remote location where NOAA Dst files are located

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ Change Log
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
+[0.2.2] - 2025-10-07
+--------------------
+* Bugs
+  * Fixed the remote location where NOAA Dst files are located
+  * Fixed error in loading the 45-day F10.7 forecasts
+
 [0.2.1] - 2024-11-18
 --------------------
 * Enhancements

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,10 +21,10 @@ classifiers = [
   "License :: OSI Approved :: BSD License",
   "Natural Language :: English",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Operating System :: POSIX :: Linux",
   "Operating System :: MacOS :: MacOS X",
   "Operating System :: Microsoft :: Windows"

--- a/pysatSpaceWeather/instruments/methods/swpc.py
+++ b/pysatSpaceWeather/instruments/methods/swpc.py
@@ -875,7 +875,7 @@ def recent_ap_f107_download(name, date_array, data_path,
 
         # Get the F107
         raw_f107 = raw_data.split('45-DAY F10.7 CM FLUX FORECAST')[-1]
-        raw_f107 = raw_f107.split('\n')[1:-4]
+        raw_f107 = raw_f107.split('\n')[1:10]
 
         # Parse the data
         ap_times, ap = parse_45day_block(raw_ap)

--- a/pysatSpaceWeather/instruments/sw_dst.py
+++ b/pysatSpaceWeather/instruments/sw_dst.py
@@ -286,7 +286,7 @@ def download(date_array, tag, inst_id, data_path, mock_download_dir=None):
 
             # User anonymous, passwd anonymous@
             ftp.login()
-            ftp.cwd('/STP/GEOMAGNETIC_DATA/INDICES/DST')
+            ftp.cwd('/STP/space-weather/geomagnetic-data/INDICES/DST')
 
         # Data stored by year. Only download for unique set of input years.
         years = np.array([date.year for date in date_array])

--- a/pysatSpaceWeather/tests/test_instruments.py
+++ b/pysatSpaceWeather/tests/test_instruments.py
@@ -49,6 +49,21 @@ class TestInstruments(clslib.InstLibTests):
 
     """
 
+    def test_45day_forecast_data_length(self):
+        """Test that the downloaded 45-day forecasts load 45 days of data."""
+        # Initalize the desired instrument parameters
+        inst_dict = {'inst_module': pysatSpaceWeather.instruments.sw_f107,
+                     'tag': '45day', 'inst_id': ''}
+        _, date = clslib.initialize_test_inst_and_date(inst_dict)
+
+        # Load the downloaded data
+        self.test_inst = pysat.Instrument(**inst_dict)
+        self.test_inst.load(date=date)
+
+        # Test that 45 days of F10.7 data are available
+        assert len(self.test_inst['f107']) == 45
+        return
+
 
 class TestSWInstrumentLogging(object):
     """Test logging messages raised under instrument-specific conditions."""


### PR DESCRIPTION
# Description

Addresses maintainence issues where Dst data at NOAA moved locations and the files at SWPC for the 45 day forecast had a different number of comments at the end.

# Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Added a new unit test.  Also:

```
import pysat
import pysatSpaceWeather as pysw

f107 = pysat.Instrument(inst_module=pysw.instruments.sw_f107, tag='45day')
f107.download()
f107.load(date=f107.today())

print(len(f107['f107']))
```
The 45-day forecast should have 45 values

## Test Configuration
* Operating system: OSX Ventura
* Version number: Python 3.10
* Any details about your local setup that are relevant

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the
release checklist on the pysat wiki:
https://github.com/pysat/pysat/wiki/Checklist-for-Release
